### PR TITLE
WIP Work Item Estimate Filter

### DIFF
--- a/src/model/estimateFilter.ts
+++ b/src/model/estimateFilter.ts
@@ -1,0 +1,5 @@
+export enum EstimateFilter {
+    Unestimated = 0,
+    Estimated = 1,
+    All = 2
+}

--- a/src/pages/session/channelSaga.ts
+++ b/src/pages/session/channelSaga.ts
@@ -18,7 +18,7 @@ import { getSnapshot } from "./selector";
 import {
     estimate,
     estimateSet,
-    estimateUpdated,
+    estimateUpdated,    
     reveal,
     revealed,
     selectWorkItem,

--- a/src/pages/session/components/sessionEstimateFilter.tsx
+++ b/src/pages/session/components/sessionEstimateFilter.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 interface ISessionEstimateFilter {
     estimateFilter: EstimateFilter;
+    updateFilter: (filter: EstimateFilter) => {}
 }
 
 export class SessionEstimateFilter extends React.Component<ISessionEstimateFilter> {
@@ -14,8 +15,13 @@ export class SessionEstimateFilter extends React.Component<ISessionEstimateFilte
 
     estimateFilter: EstimateFilter = EstimateFilter.All;
 
+    updateFilter(filter: EstimateFilter) {
+        this.estimateFilter = filter;
+    }
+
     render(): JSX.Element {
         const {
+            estimateFilter
         } = this.props;
 
         return (
@@ -25,8 +31,8 @@ export class SessionEstimateFilter extends React.Component<ISessionEstimateFilte
                         value={this.props.estimateFilter}
                         onInput={
                             (() => {
-                                this.props.updateFilter(
-                                    this.estimateFilter
+                                this.updateFilter(
+                                    estimateFilter
                                 );
                             })
                 }/>

--- a/src/pages/session/components/sessionEstimateFilter.tsx
+++ b/src/pages/session/components/sessionEstimateFilter.tsx
@@ -1,0 +1,43 @@
+import { EstimateFilter } from "../../../model/estimateFilter";
+import React from "react";
+
+interface ISessionEstimateFilter {
+    estimateFilter: EstimateFilter;
+}
+
+export class SessionEstimateFilter extends React.Component<ISessionEstimateFilter> {
+
+
+    constructor(props: any){
+        super(props);
+    }
+
+    estimateFilter: EstimateFilter = EstimateFilter.All;
+
+    render(): JSX.Element {
+        const {
+            updateFilter
+        } = this.props;
+
+        return (
+            <div className="work-item-list-filter flex-grow flex-center">
+                <input type="range" 
+                        list="estimate-filter-values" 
+                        value={this.props.estimateFilter}
+                        onInput={
+                            (() => {
+                                this.props.updateFilter(
+                                    this.estimateFilter
+                                );
+                            })
+                }/>
+
+                <datalist id="estimate-filter-values">
+                    <option value="0" label="No Est."></option>
+                    <option value="1" label="All"></option>
+                    <option value="2" label="Estimated"></option>
+                </datalist>
+            </div>
+        )
+    }
+}

--- a/src/pages/session/components/sessionEstimateFilter.tsx
+++ b/src/pages/session/components/sessionEstimateFilter.tsx
@@ -16,7 +16,6 @@ export class SessionEstimateFilter extends React.Component<ISessionEstimateFilte
 
     render(): JSX.Element {
         const {
-            updateFilter
         } = this.props;
 
         return (

--- a/src/pages/session/session.tsx
+++ b/src/pages/session/session.tsx
@@ -31,7 +31,8 @@ import {
     leaveSession,
     loadedSession,
     loadSession,
-    selectWorkItem
+    selectWorkItem,
+    filterCards
 } from "./sessionActions";
 import { EstimateFilter } from "../../model/estimateFilter";
 
@@ -52,7 +53,6 @@ interface ISessionProps extends IPageProps<ISessionParams> {
     cardSet: ICardSet;
     selectedWorkItem: IWorkItem | null;
     activeUsers: IUserInfo[];
-
     canPerformAdminActions: boolean;
 }
 
@@ -61,7 +61,8 @@ const Actions = {
     loadedSession,
     selectWorkItem,
     leaveSession,
-    endSession
+    endSession,
+    filterCards  
 };
 
 class Session extends React.Component<
@@ -159,10 +160,7 @@ class Session extends React.Component<
 
                 <div className="page-content page-content-top flex-row session-content">
 
-                    <SessionEstimateFilter 
-                        updateFilter={(value: EstimateFilter) => { 
-                                        this.estimateFilter = value; }} 
-                    />
+                    <SessionEstimateFilter estimateFilter={this.estimateFilter} updateFilter={(value: EstimateFilter) => this.estimateFilter = value} />
 
                     <div className="work-item-list v-scroll-auto flex-column custom-scrollbar flex-noshrink">
                         {workItems.filter(workItem => {

--- a/src/pages/session/session.tsx
+++ b/src/pages/session/session.tsx
@@ -24,6 +24,7 @@ import { IState } from "../../reducer";
 import { IPageProps } from "../props";
 import WorkItemView from "./components/workItemView";
 import { getActiveUsers, canPerformAdminActions } from "./selector";
+import { SessionEstimateFilter } from "./components/sessionEstimateFilter"; 
 import "./session.scss";
 import {
     endSession,
@@ -32,6 +33,7 @@ import {
     loadSession,
     selectWorkItem
 } from "./sessionActions";
+import { EstimateFilter } from "../../model/estimateFilter";
 
 interface ISessionParams {
     id: string;
@@ -46,6 +48,7 @@ interface ISessionProps extends IPageProps<ISessionParams> {
     session: ISession;
     workItems: IWorkItem[];
     estimates: ISessionEstimates;
+    estimateFilter: EstimateFilter;
     cardSet: ICardSet;
     selectedWorkItem: IWorkItem | null;
     activeUsers: IUserInfo[];
@@ -76,6 +79,8 @@ class Session extends React.Component<
     componentDidMount() {
         this.props.loadSession(this.props.match.params.id);
     }
+
+    estimateFilter: EstimateFilter = EstimateFilter.All;
 
     render(): JSX.Element {
         const {
@@ -153,8 +158,24 @@ class Session extends React.Component<
                 </CustomHeader>
 
                 <div className="page-content page-content-top flex-row session-content">
+
+                    <SessionEstimateFilter 
+                        updateFilter={(value: EstimateFilter) => { 
+                                        this.estimateFilter = value; }} 
+                    />
+
                     <div className="work-item-list v-scroll-auto flex-column custom-scrollbar flex-noshrink">
-                        {workItems.map(workItem => (
+                        {workItems.filter(workItem => {
+                                switch(this.estimateFilter){
+                                    case 0:
+                                        return workItem.estimate;
+                                    case 1:
+                                        return (!workItem.estimate || workItem.estimate == 0);
+                                    case 2:
+                                        return true;
+                                }
+                            }
+                        ).map(workItem => (
                             <WorkItemCard
                                 key={workItem.id}
                                 cardSet={cardSet}
@@ -195,6 +216,7 @@ export default connect(
             cardSet: state.session.cardSet,
             workItems: state.session.workItems,
             estimates: state.session.estimates,
+            estimateFilter: state.session.estimateFilter,
             selectedWorkItem: state.session.selectedWorkItem,
             activeUsers: getActiveUsers(state),
             canPerformAdminActions: canPerformAdminActions(state)

--- a/src/pages/session/sessionActions.ts
+++ b/src/pages/session/sessionActions.ts
@@ -5,6 +5,7 @@ import { ISession } from "../../model/session";
 import { IUserInfo } from "../../model/user";
 import { IWorkItem } from "../../model/workitem";
 import { ISnapshot } from "../../model/snapshots";
+import { EstimateFilter } from "../../model/estimateFilter";
 
 const factory = actionCreatorFactory("session");
 
@@ -48,3 +49,5 @@ export const userJoined = factory<IUserInfo>("userJoined");
 export const userLeft = factory<string>("userLeft");
 
 export const snapshotReceived = factory<ISnapshot>("snapshotReceived");
+
+export const workItemsFiltered = factory<EstimateFilter>("workItemsFiltered");

--- a/src/pages/session/sessionActions.ts
+++ b/src/pages/session/sessionActions.ts
@@ -50,4 +50,4 @@ export const userLeft = factory<string>("userLeft");
 
 export const snapshotReceived = factory<ISnapshot>("snapshotReceived");
 
-export const workItemsFiltered = factory<EstimateFilter>("workItemsFiltered");
+export const filterCards = factory<EstimateFilter>("filterCards");

--- a/src/pages/session/sessionReducer.ts
+++ b/src/pages/session/sessionReducer.ts
@@ -6,6 +6,7 @@ import { ISession } from "../../model/session";
 import { IUserInfo } from "../../model/user";
 import { IWorkItem } from "../../model/workitem";
 import * as Actions from "./sessionActions";
+import { EstimateFilter } from "../../model/estimateFilter";
 
 export const initialState = {
     status: {
@@ -18,6 +19,7 @@ export const initialState = {
     selectedWorkItem: null as IWorkItem | null,
     ownEstimate: null as IEstimate | null,
     estimates: {} as ISessionEstimates,
+    estimateFilter: {} as EstimateFilter,
     revealed: false,
     activeUsers: [] as IUserInfo[],
     currentUser: null as IUserInfo | null

--- a/src/services/channels/signalr.ts
+++ b/src/services/channels/signalr.ts
@@ -5,6 +5,7 @@ import { IdentityServiceId, IIdentityService } from "../identity";
 import { Services } from "../services";
 import { defineIncomingOperation, defineOperation, IChannel } from "./channels";
 import { ISnapshot } from "../../model/snapshots";
+import { EstimateFilter } from "../../model/estimateFilter";
 
 const baseUrl = "https://estimate-backend.azurewebsites.net/";
 
@@ -16,7 +17,8 @@ enum Action {
     Reveal = "reveal",
     Add = "add",
     Switch = "switch",
-    Snapshot = "snapshot"
+    Snapshot = "snapshot",
+    Filter = "filter"
 }
 
 export class SignalRChannel implements IChannel {
@@ -50,6 +52,10 @@ export class SignalRChannel implements IChannel {
     snapshot = defineOperation<ISnapshot>(async snapshot => {
         await this.sendToOtherClients(Action.Snapshot, snapshot);
     });
+
+    filter = defineOperation<EstimateFilter>(async filterValue => {
+        await this.sendToOtherClients(Action.Filter, filterValue);
+    })
 
     private connection: signalR.HubConnection | undefined;
     private sessionId: string = "";
@@ -139,6 +145,12 @@ export class SignalRChannel implements IChannel {
             case Action.Snapshot: {
                 this.snapshot.incoming(payload);
                 break;
+            }
+
+            case Action.Filter: {
+                // A user has changed the value of the 
+                // EstimateFilter selector
+                this.filter.incoming(payload);
             }
 
             default: {


### PR DESCRIPTION
This PR addresses #48, to give session users the ability to filter the work item card list in three ways.

## Filter Options:
1. Show All (Unfiltered)
2. Show Only Unestimated Work Items
3. Show Only Work Items with an estimate


## Live Updating
This update is intended to allow the Estimate Filter to update the work item list for all users connected to a session.

